### PR TITLE
Add comprehensive curriculum blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Progressive learning and execution platform for AI Architects, program leaders, 
 ## Strategic References
 - [Product Blueprint](docs/product-blueprint.md)
 - [Platform Strategy](docs/strategy.md)
+- [Curriculum Blueprint](docs/curriculum-blueprint.md)
 - [Capabilities & Agentic Specs](docs/capabilities.md)
 - [Agent Journey Mapping](docs/agent-journeys.md)
 - [UI / UX Principles](docs/ui-ux-principles.md)

--- a/docs/curriculum-blueprint.md
+++ b/docs/curriculum-blueprint.md
@@ -1,0 +1,123 @@
+# AI Architect Academy Curriculum Blueprint
+
+## Purpose & Outcomes
+The curriculum is a living operating system for producing elite AI Architects and program leaders. It combines vetted casework, frontier research, and governed delivery practices so graduates can:
+- Design and ship production-grade AI systems with measurable business impact.
+- Operationalize responsible AI controls across data, model, and experience layers.
+- Lead cross-functional teams, companion agents, and automation in fast-moving environments.
+- Continually adapt architectures, tooling, and governance to the evolving AI landscape.
+
+## Learning Philosophy
+1. **Truth-first & current** – every module sources from peer-reviewed research, vendor documentation, regulatory updates, and field-tested playbooks. Change logs capture updates, and the assistant cites sources by default.
+2. **Micro-to-systems mastery** – concepts arrive in digestible micro-lessons that ladder into systems-level blueprints, with optional deep dives for specialists.
+3. **Learning while shipping** – labs, deliverables, and capstones mirror production workloads so every learner creates evidence they can deploy immediately.
+4. **Agent-augmented teaching** – the AI Architect Assistant co-facilitates lessons, critiques deliverables, and surfaces fresh intel on demand.
+5. **Community accountability** – cohorts, mentors, and partner experts provide feedback loops, story-driven reflections, and governance reviews.
+
+### Modalities & Cadence
+| Modality | Format | Cadence | Purpose |
+| --- | --- | --- | --- |
+| Pulse Briefings | 10-minute weekly video + transcript | Weekly | Synthesize research updates, regulatory changes, tooling shifts. |
+| Micro-Lessons | MDX module with interactive snippets | 2–3 per week | Teach focused concepts linked to deliverables and citations. |
+| Studio Labs | Guided notebooks, repo exercises, agent sandboxes | Bi-weekly | Apply concepts on real infrastructure with assistant support. |
+| Capstone Sprints | Multi-week projects with stakeholder checkpoints | Quarterly | Deliver end-to-end architecture packages with evidence. |
+| Governance Reviews | Panel critique with risk/compliance experts | Monthly | Pressure-test controls, evaluation plans, and audit readiness. |
+| Portfolio Retros | Cohort forum + async video reflection | Monthly | Capture learnings, share playbooks, feed knowledge graph. |
+
+## Mastery Ladder
+| Level | Focus | Signature Evidence | Graduation Criteria |
+| --- | --- | --- | --- |
+| Explorer | Foundations of AI architecture, responsible AI principles | Architecture canvas, risk register draft | Complete 6 core micro-lessons, pass fundamentals assessment (80%). |
+| Builder | Delivery patterns, data pipelines, evaluation mechanics | Working RAG service, evaluation dashboard | Ship studio lab deliverables, 2 governance reviews accepted. |
+| Architect | Multi-system design, automation, scaling operations | Platform blueprint, integration runbook | Complete capstone sprint, lead cross-functional critique. |
+| Strategist | Portfolio orchestration, executive storytelling, agent ecosystems | Board-ready roadmap, AI portfolio scorecard | Run executive simulation, maintain portfolio telemetry for 4 weeks. |
+| Luminary | Frontier research synthesis, policy influence, community leadership | Published insight kit, open-source contribution | Author 3 knowledge assets, mentor two cohorts, 95% evaluation confidence. |
+
+## Track Architecture & Module Families
+Each track contains guided sequences with prerequisites, deliverables, and rubrics. Modules interlink through shared schemas so the assistant can recommend adjacent learning.
+
+### 1. Foundations & Systems Thinking
+- **Core Modules**: AI Architect Mission Charter, Systems Thinking for AI, Responsible AI Fundamentals, Socio-Technical Risk Patterns, Data Governance 101.
+- **Deep Dives**: Foundation Model Primer, Retrieval Augmented Generation (RAG) Concepts, Policy & Regulation Landscape 2024.
+- **Deliverables**: Mission canvas, capability map, high-level risk inventory, ethical guardrail statement.
+
+### 2. Data, Models & Evaluation Engineering
+- **Core Modules**: Data Quality Ops, Feature & Embedding Stores, Model Lifecycle Management, Evaluation Frameworks, Synthetic Data Practices.
+- **Labs**: Supabase + pgvector RAG lab, LangSmith/Langfuse evaluation notebook, synthetic data pipeline sandbox.
+- **Deliverables**: Data governance checklist, evaluation rubric, automated regression suite with metrics dashboard.
+
+### 3. Solution Delivery & Platform Ops
+- **Core Modules**: Reference Architectures, Multi-cloud Deployment, Observability Patterns, Guardrail Tooling, Incident Response for AI.
+- **Integrations**: Terraform baseline, Kubernetes + inference services, CI/CD for LLMOps.
+- **Deliverables**: Infrastructure diagram, IaC repo, runbook for fallbacks and rollbacks, incident simulation report.
+
+### 4. Responsible AI & Governance
+- **Core Modules**: Policy Mapping, Risk & Control Libraries, Human-in-the-loop Design, Evaluation Governance, Documentation Automation.
+- **Casework**: NIST AI RMF alignment, EU AI Act readiness, sector-specific compliance (finance, healthcare, public sector).
+- **Deliverables**: Control matrix, policy-to-control traceability map, evidence packaging plan, red-team/blue-team drill.
+
+### 5. Product Leadership & Value Acceleration
+- **Core Modules**: Value Narratives & Business Cases, Stakeholder Alignment, ROI Instrumentation, Change Management, Program Operating Rhythm.
+- **Workshops**: Executive storytelling simulator, backlog prioritization with weighted outcomes, metrics instrumentation lab.
+- **Deliverables**: Executive briefing deck, KPI stack, operating cadence charter, success metrics instrumentation plan.
+
+### 6. Companion Agents & Automation Ecosystems
+- **Core Modules**: Agentic Patterns, Tool Orchestration, Context Management, Memory Architectures, Safety & Guardrails for Agents.
+- **Labs**: Auto-evaluating agents, workflow graph generation, compliance-aware agent operations.
+- **Deliverables**: Agent action graph, retrieval schema, policy-constrained agent plan, auto-eval scenario library.
+
+### 7. Frontier Innovation & Research Translation
+- **Core Modules**: Multimodal Systems, On-device/Edge AI, Privacy-Preserving Techniques, Federated Learning, Model Alignment & Red-teaming.
+- **Research Forums**: Paper clubs, vendor/OSS briefings, patent landscape reviews.
+- **Deliverables**: Research translation brief, experimentation backlog, innovation pipeline roadmap.
+
+## Module Blueprint & Metadata
+- **Front matter schema**: `title`, `outcomes`, `prerequisites`, `tags` (persona, maturity, track, deliverable, governance), `assets`, `evaluation-rubric`, `evidence-artifacts`, `last-reviewed`.
+- **Learning flow**: concept primer → guided exploration → assistant co-pilot tasks → studio lab (optional) → reflection prompts → deliverable submission → peer/assistant critique.
+- **Accessibility**: transcripts, code sandboxes, captions, high-contrast design, asynchronous alternatives for every live session.
+
+## Labs, Capstones & Certification
+- **Studio Labs** connect to GitHub templates, Supabase sandboxes, and Qdrant/Weaviate test clusters for retrieval work.
+- **Capstone Sprints** require learners to design, build, and document a governed AI product in four weeks, culminating in an executive simulation and governance audit.
+- **Portfolio Certification** ties module completions, governance scores, and stakeholder feedback into an authenticated credential (OpenBadge + verifiable credential JSON).
+
+## Assessment & Evidence System
+1. **Automated Checks** – lint deliverables against rubric criteria (coverage, traceability, documentation completeness).
+2. **Assistant Critique** – RAG-backed reasoning that flags missing citations, risks, or control gaps.
+3. **Peer Review** – cohort peers review asynchronously with structured feedback templates.
+4. **Expert Panels** – monthly live or recorded reviews by architects, compliance, and product leaders.
+5. **Longitudinal Signals** – telemetry on production deployments, incident logs, and ROI metrics feeds alumni dashboards.
+
+## Curriculum Update Operating System
+- **Signals Intake**: track research feeds (arXiv, regulatory bodies), vendor roadmaps, and community contributions.
+- **Curator Pods**: dedicated squads own each track, conduct monthly literature scans, and propose updates via change requests.
+- **Versioning**: semantic version per module (`major.minor.patch`), with release notes stored in the knowledge graph.
+- **Assistant Refresh**: nightly embedding updates, metadata diffing, and auto-generated summaries of what changed for learners.
+- **Quality Gates**: automated plagiarism checks, fact verification via retrieval, and human sign-off before publishing.
+
+## Cohort Experience & Support Systems
+- **Onboarding**: orientation micro-path tailored by persona and goals, assistant-led tour, readiness survey.
+- **Daily Flow**: stand-up check-ins (async), micro-lesson drop, assistant nudge for deliverables, optional live office hours.
+- **Mentorship**: rotating roster of principal architects, risk leaders, and product strategists; mentor assignments triggered by telemetry (e.g., stalled progress, flagged risks).
+- **Community Spaces**: private Discord/Slack with channel taxonomy by track; knowledge base auto-summarized weekly.
+- **Wellness & Sustainability**: burnout check-ins, focus sprints, optional AI ethicist support for sensitive work.
+
+## Assistant Integration Blueprint
+- **Context Packs**: curated embeddings per track with citations, diagrams, deliverables, and policy references.
+- **Tool Suite**: plan synthesizer, rubric scorer, evaluation lab launcher, compliance mapper, stakeholder comms generator.
+- **Meta-learning**: assistant tracks learner gaps, suggests spaced repetition prompts, and simulates stakeholder Q&A.
+- **Agent Interoperability**: APIs allow companion agents to fetch module manifests, schedule labs, or submit reflections.
+
+## Success Metrics
+- 85% of learners ship production-ready deliverables within six weeks of enrollment.
+- 90% of governance reviews meet or exceed compliance thresholds on first submission.
+- 70% of alumni lead AI initiative portfolios within six months.
+- 95% assistant satisfaction rating across critique, planning, and research tasks.
+- Community contributions add ≥12 new vetted modules or playbooks per quarter.
+
+## Next Actions
+1. Implement MDX front matter schema in the content pipeline and tag existing modules accordingly.
+2. Launch track-specific curator pods and schedule monthly research synthesis briefings.
+3. Build assistant rubric scorer MVP with retrieval prompts tied to module metadata.
+4. Publish cohort onboarding flow with orientation micro-paths and telemetry instrumentation.
+5. Design credentialing workflow (badge, verifiable credential JSON, API) and pilot with alpha cohort.


### PR DESCRIPTION
## Summary
- add a curriculum blueprint detailing learning philosophy, tracks, mastery ladder, and update operations for the academy
- document advanced teaching modalities, assessment model, and assistant integration for AI Architect education
- link the new curriculum blueprint from the repository README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb3d634754832088f0802718d414b8