### PR TITLE
Scaffold data adapters and replace mailto with waitlist intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Progressive learning and execution platform for AI Architects, program leaders, 
 
 ## Community + Support
 - Discussions/issues: [GitHub repo](https://github.com/frankxai/saas-ai-architect-academy).
-- Partnerships & cohorts: [frank@aiarchitect.academy](mailto:frank@aiarchitect.academy).
+- Partnerships & cohorts: Join the [Academy waitlist](https://saas-ai-architect-academy.vercel.app/#waitlist) or email frank@aiarchitect.academy.
 
 Built in public to accelerate real-world AI value delivery.
 

--- a/src/app/curriculum/modules/[code]/page.tsx
+++ b/src/app/curriculum/modules/[code]/page.tsx
@@ -141,7 +141,7 @@ export default function ModuleDetail({ params }: { params: { code: string } }) {
               </Link>
             )}
             <Link
-              href="mailto:frank@aiarchitect.academy"
+              href="/#waitlist"
               className="rounded-full border border-white/20 px-4 py-2 text-slate-100 transition hover:border-cyan-300 hover:text-cyan-200"
             >
               Schedule mentor review

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -92,7 +93,7 @@ export default function RootLayout({
         >
           {JSON.stringify(organizationJsonLd)}
         </Script>
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { ProgressIndicator } from "@/components/ui/progress-indicator";
 import { SectionHeader, SectionShell } from "@/components/ui/section";
+import { WaitlistSection } from "@/components/waitlist/waitlist-form";
 
 const navLinks = [
   { label: "Vision", href: "#vision" },
@@ -13,6 +14,7 @@ const navLinks = [
   { label: "Personas", href: "#personas" },
   { label: "Services", href: "#services" },
   { label: "Resources", href: "#resources" },
+  { label: "Waitlist", href: "/#waitlist" },
 ];
 
 const heroHighlights = [
@@ -300,7 +302,7 @@ const serviceOffers = [
       "Executive-ready narrative plus board briefing artefacts",
     ],
     ctaLabel: "Book the sprint",
-    href: "mailto:frank@aiarchitect.academy?subject=Executive%20Governance%20Sprint",
+    href: "/#waitlist",
   },
   {
     title: "Enterprise Transformation Lab",
@@ -313,7 +315,7 @@ const serviceOffers = [
       "OKR and ROI instrumentation plus handover playbook",
     ],
     ctaLabel: "Schedule lab consult",
-    href: "mailto:frank@aiarchitect.academy?subject=Enterprise%20Transformation%20Lab",
+    href: "/#waitlist",
   },
   {
     title: "Creator Influence Accelerator",
@@ -326,7 +328,7 @@ const serviceOffers = [
       "Analytics dashboard with sponsorship and conversion insights",
     ],
     ctaLabel: "Request media kit",
-    href: "mailto:frank@aiarchitect.academy?subject=Creator%20Influence%20Accelerator",
+    href: "/#waitlist",
   },
   {
     title: "Inner Circle Advisory",
@@ -339,7 +341,7 @@ const serviceOffers = [
       "Early invites to launches, masterminds, and community rituals",
     ],
     ctaLabel: "Join the advisory",
-    href: "mailto:frank@aiarchitect.academy?subject=Inner%20Circle%20Advisory",
+    href: "/#waitlist",
   },
 ];
 
@@ -406,19 +408,19 @@ const resourceVault = [
         name: "Executive Governance Sprint",
         summary: "Four-week engagement aligning policy, evaluation, and launch rhythms.",
         format: "Advisory sprint",
-        href: "mailto:frank@aiarchitect.academy?subject=Executive%20Governance%20Sprint",
+        href: "/#waitlist",
       },
       {
         name: "Enterprise Transformation Lab",
         summary: "Embedded partnership shipping governed architectures and enablement.",
         format: "Advisory lab",
-        href: "mailto:frank@aiarchitect.academy?subject=Enterprise%20Transformation%20Lab",
+        href: "/#waitlist",
       },
       {
         name: "Creator Influence Accelerator",
         summary: "Systems, analytics, and assistant prompts for multi-channel influence.",
         format: "Creator accelerator",
-        href: "mailto:frank@aiarchitect.academy?subject=Creator%20Influence%20Accelerator",
+        href: "/#waitlist",
       },
     ],
   },
@@ -501,7 +503,7 @@ function HeroSection() {
               Browse modules & labs
             </Link>
             <Link
-              href="mailto:frank@aiarchitect.academy"
+              href="/#waitlist"
               className="rounded-full border border-white/20 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300 hover:text-cyan-200"
             >
               Talk to the team
@@ -689,10 +691,10 @@ function AssistantSection() {
             </li>
           </ul>
           <p className="mt-4 text-xs text-slate-300">
-            Want to help wire the Supabase experience? Reach out and we will provision a build preview with the current MVP.
+            Want to help wire the Supabase experience? Drop your details and we will invite you to the integration preview.
           </p>
           <Link
-            href="mailto:frank@aiarchitect.academy?subject=Supabase%20Workspace%20Collab"
+            href="/#waitlist"
             className="mt-4 inline-flex w-max rounded-full bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-slate-200"
           >
             Support the MVP build
@@ -863,7 +865,7 @@ function ClosingCta() {
             Explore module atlas
           </Link>
           <Link
-            href="mailto:frank@aiarchitect.academy"
+            href="/#waitlist"
             className="rounded-full border border-white/20 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300 hover:text-cyan-200"
           >
             Become a launch partner
@@ -884,8 +886,9 @@ function Footer() {
             <span className="text-[11px] uppercase tracking-[0.35em] text-cyan-200">AI Architect Academy</span>
           </div>
           <div className="flex flex-wrap gap-3">
-            <Link href="mailto:frank@aiarchitect.academy" className="hover:text-cyan-200">
-              frank@aiarchitect.academy
+            <span className="hover:text-cyan-200">frank@aiarchitect.academy</span>
+            <Link href="/#waitlist" className="hover:text-cyan-200">
+              Join waitlist
             </Link>
             <Link href="https://github.com/frankxai/saas-ai-architect-academy" target="_blank" className="hover:text-cyan-200">
               GitHub
@@ -925,6 +928,7 @@ export default function HomePage() {
         <PersonaSection />
         <ServicesSection />
         <ResourceSection />
+        <WaitlistSection />
         <ClosingCta />
       </main>
       <Footer />

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { DataEnvironmentProvider } from "@/lib/data/data-environment";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <DataEnvironmentProvider>{children}</DataEnvironmentProvider>;
+}

--- a/src/app/workspaces/page.tsx
+++ b/src/app/workspaces/page.tsx
@@ -360,7 +360,7 @@ export default function WorkspacePage() {
           </div>
           <div className="mt-8 flex flex-wrap gap-3 text-xs">
             <Link
-              href="mailto:frank@aiarchitect.academy?subject=Workspace%20MVP%20Support"
+              href="/#waitlist"
               className="rounded-full bg-white px-4 py-2 font-semibold uppercase tracking-[0.3em] text-slate-900 transition hover:bg-slate-200"
             >
               Join the build circle

--- a/src/components/waitlist/waitlist-form.tsx
+++ b/src/components/waitlist/waitlist-form.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
+
+import { useWaitlistAdapter } from "@/lib/data/data-environment";
+import type { LearnerFocusArea, WaitlistSubmission } from "@/lib/data/types";
+
+const focusAreas: { value: LearnerFocusArea; label: string }[] = [
+  { value: "agents", label: "Agent Systems" },
+  { value: "prototyping", label: "Rapid Prototyping" },
+  { value: "operations", label: "Architecture & Ops" },
+  { value: "governance", label: "Governance" },
+  { value: "story", label: "Story & Scale" },
+];
+
+const tiers = [
+  { value: "workspace" as const, label: "Learner Workspace" },
+  { value: "advisory" as const, label: "Executive Advisory" },
+  { value: "creator" as const, label: "Creator Studio" },
+  { value: "enterprise" as const, label: "Enterprise Transformation" },
+];
+
+const initialFormState = {
+  fullName: "",
+  email: "",
+  role: "",
+  focusArea: focusAreas[0]!.value,
+  desiredTier: tiers[0]!.value,
+  notes: "",
+};
+
+type FormState = typeof initialFormState;
+
+type SubmissionStatus = "idle" | "submitting" | "success" | "error";
+
+function createPayload(form: FormState): WaitlistSubmission {
+  const notes = form.notes.trim();
+  return {
+    fullName: form.fullName.trim(),
+    email: form.email.trim().toLowerCase(),
+    role: form.role.trim(),
+    focusArea: form.focusArea,
+    desiredTier: form.desiredTier,
+    notes: notes.length ? notes : undefined,
+    submittedAt: new Date().toISOString(),
+  };
+}
+
+export function WaitlistForm() {
+  const waitlist = useWaitlistAdapter();
+  const [form, setForm] = useState<FormState>(initialFormState);
+  const [status, setStatus] = useState<SubmissionStatus>("idle");
+  const disableSubmit = useMemo(() => {
+    if (status === "submitting") return true;
+    return !form.fullName.trim() || !form.email.trim() || !form.role.trim();
+  }, [form.email, form.fullName, form.role, status]);
+
+  const handleChange = (field: keyof FormState) => (event: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+    if (status === "success" || status === "error") {
+      setStatus("idle");
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (disableSubmit) return;
+    setStatus("submitting");
+    try {
+      await waitlist.submit(createPayload(form));
+      setStatus("success");
+      setForm(initialFormState);
+    } catch (error) {
+      console.error("Waitlist submission failed", error);
+      setStatus("error");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="flex flex-col text-sm font-medium text-slate-900 dark:text-slate-100">
+          Full name
+          <input
+            required
+            value={form.fullName}
+            onChange={handleChange("fullName")}
+            placeholder="Frank Martinez"
+            className="mt-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+            type="text"
+            name="fullName"
+            autoComplete="name"
+          />
+        </label>
+        <label className="flex flex-col text-sm font-medium text-slate-900 dark:text-slate-100">
+          Email
+          <input
+            required
+            value={form.email}
+            onChange={handleChange("email")}
+            placeholder="you@company.com"
+            className="mt-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+            type="email"
+            name="email"
+            autoComplete="email"
+          />
+        </label>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="flex flex-col text-sm font-medium text-slate-900 dark:text-slate-100">
+          Role / Title
+          <input
+            required
+            value={form.role}
+            onChange={handleChange("role")}
+            placeholder="Head of AI Architecture"
+            className="mt-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+            type="text"
+            name="role"
+            autoComplete="organization-title"
+          />
+        </label>
+        <label className="flex flex-col text-sm font-medium text-slate-900 dark:text-slate-100">
+          Primary focus area
+          <select
+            value={form.focusArea}
+            onChange={handleChange("focusArea")}
+            className="mt-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+            name="focusArea"
+          >
+            {focusAreas.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="flex flex-col text-sm font-medium text-slate-900 dark:text-slate-100">
+          Service tier interest
+          <select
+            value={form.desiredTier}
+            onChange={handleChange("desiredTier")}
+            className="mt-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+            name="desiredTier"
+          >
+            {tiers.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col text-sm font-medium text-slate-900 dark:text-slate-100">
+          Notes (optional)
+          <textarea
+            value={form.notes}
+            onChange={handleChange("notes")}
+            placeholder="Share context, goals, or timeline expectations"
+            className="mt-2 min-h-[112px] rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+            name="notes"
+          />
+        </label>
+      </div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="submit"
+          disabled={disableSubmit}
+          className="inline-flex w-full items-center justify-center rounded-full bg-cyan-500 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-slate-950 transition hover:bg-cyan-400 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+        >
+          {status === "submitting" ? "Joining waitlist..." : "Join the waitlist"}
+        </button>
+        <StatusMessage status={status} />
+      </div>
+    </form>
+  );
+}
+
+function StatusMessage({ status }: { status: SubmissionStatus }) {
+  if (status === "success") {
+    return <p className="text-sm text-emerald-500">Saved! We will reach out as soon as onboarding opens.</p>;
+  }
+  if (status === "error") {
+    return <p className="text-sm text-rose-500">Something went wrong. Please try again.</p>;
+  }
+  return <p className="text-sm text-slate-500">We respond within one business day for executive and enterprise cohorts.</p>;
+}
+
+export function WaitlistSection() {
+  return (
+    <section id="waitlist" className="relative isolate overflow-hidden bg-slate-900 py-16 sm:py-24">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.18),_transparent_55%)]" aria-hidden="true" />
+      <div className="mx-auto flex max-w-5xl flex-col gap-10 px-6 text-white sm:px-10">
+        <div className="space-y-4 text-center sm:text-left">
+          <p className="text-sm font-semibold uppercase tracking-[0.4em] text-cyan-300">Stay in the loop</p>
+          <h2 className="text-3xl font-bold sm:text-4xl">Reserve your spot in the AI Architect Academy</h2>
+          <p className="max-w-3xl text-base text-cyan-100/90">
+            Tell us where you want the assistant, curriculum, and advisory services to plug into your roadmap. We will ship the
+            Supabase-backed workspace shortly—sign up now and we will notify you the moment the beta opens.
+          </p>
+        </div>
+        <div className="rounded-3xl border border-cyan-500/40 bg-slate-950/60 p-6 shadow-[0_0_80px_rgba(34,211,238,0.12)] backdrop-blur sm:p-10">
+          <WaitlistForm />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/data/adapters/local-storage.ts
+++ b/src/lib/data/adapters/local-storage.ts
@@ -1,0 +1,128 @@
+"use client";
+
+import type {
+  DataEnvironment,
+  LearnerProgressAdapter,
+  LearnerProgressSnapshot,
+  WaitlistAdapter,
+  WaitlistSubmission,
+} from "../types";
+
+const PROGRESS_STORAGE_KEY = "ai-architect-progress";
+const WAITLIST_STORAGE_KEY = "ai-architect-waitlist";
+
+function readProgress(): LearnerProgressSnapshot {
+  if (typeof window === "undefined") {
+    return {
+      focusArea: "agents",
+      checkpoints: {},
+      lastUpdated: new Date().toISOString(),
+    };
+  }
+
+  try {
+    const stored = window.localStorage.getItem(PROGRESS_STORAGE_KEY);
+    if (!stored) {
+      return {
+        focusArea: "agents",
+        checkpoints: {},
+        lastUpdated: new Date().toISOString(),
+      };
+    }
+
+    const parsed = JSON.parse(stored) as LearnerProgressSnapshot;
+    return {
+      focusArea: parsed.focusArea ?? "agents",
+      checkpoints: parsed.checkpoints ?? {},
+      lastUpdated: parsed.lastUpdated ?? new Date().toISOString(),
+    };
+  } catch (error) {
+    console.warn("Unable to parse learner progress from localStorage", error);
+    return {
+      focusArea: "agents",
+      checkpoints: {},
+      lastUpdated: new Date().toISOString(),
+    };
+  }
+}
+
+function writeProgress(snapshot: LearnerProgressSnapshot) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(PROGRESS_STORAGE_KEY, JSON.stringify(snapshot));
+}
+
+function readWaitlist(): WaitlistSubmission[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const stored = window.localStorage.getItem(WAITLIST_STORAGE_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored) as WaitlistSubmission[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.warn("Unable to parse waitlist submissions from localStorage", error);
+    return [];
+  }
+}
+
+function writeWaitlist(entries: WaitlistSubmission[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(WAITLIST_STORAGE_KEY, JSON.stringify(entries));
+}
+
+export function createLocalLearnerProgressAdapter(): LearnerProgressAdapter {
+  const subscribers = new Set<(snapshot: LearnerProgressSnapshot) => void>();
+  let storageHandler: ((event: StorageEvent) => void) | null = null;
+
+  const ensureStorageListener = () => {
+    if (storageHandler || typeof window === "undefined") return;
+    storageHandler = (event: StorageEvent) => {
+      if (event.key !== PROGRESS_STORAGE_KEY) return;
+      const snapshot = readProgress();
+      subscribers.forEach((callback) => callback(snapshot));
+    };
+    window.addEventListener("storage", storageHandler);
+  };
+
+  const teardownStorageListener = () => {
+    if (!storageHandler || typeof window === "undefined") return;
+    window.removeEventListener("storage", storageHandler);
+    storageHandler = null;
+  };
+
+  return {
+    async load() {
+      return readProgress();
+    },
+    async save(snapshot) {
+      writeProgress(snapshot);
+      subscribers.forEach((callback) => callback(snapshot));
+    },
+    subscribe(callback) {
+      subscribers.add(callback);
+      ensureStorageListener();
+      return () => {
+        subscribers.delete(callback);
+        if (subscribers.size === 0) {
+          teardownStorageListener();
+        }
+      };
+    },
+  };
+}
+
+export function createLocalWaitlistAdapter(): WaitlistAdapter {
+  return {
+    async submit(entry) {
+      const entries = readWaitlist();
+      entries.push(entry);
+      writeWaitlist(entries);
+    },
+  };
+}
+
+export function createLocalDataEnvironment(): DataEnvironment {
+  return {
+    learnerProgress: createLocalLearnerProgressAdapter(),
+    waitlist: createLocalWaitlistAdapter(),
+  };
+}

--- a/src/lib/data/adapters/static.ts
+++ b/src/lib/data/adapters/static.ts
@@ -1,0 +1,36 @@
+import type { DataEnvironment, LearnerProgressAdapter, LearnerProgressSnapshot, WaitlistAdapter } from "../types";
+
+const fallbackSnapshot: LearnerProgressSnapshot = {
+  focusArea: "agents",
+  checkpoints: {},
+  lastUpdated: new Date().toISOString(),
+};
+
+const staticLearnerProgressAdapter: LearnerProgressAdapter = {
+  async load() {
+    return fallbackSnapshot;
+  },
+  async save() {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("Learner progress save called without a client environment. No data persisted.");
+    }
+  },
+  subscribe() {
+    return () => undefined;
+  },
+};
+
+const staticWaitlistAdapter: WaitlistAdapter = {
+  async submit() {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("Waitlist submission attempted without a client environment. No data persisted.");
+    }
+  },
+};
+
+export function createStaticDataEnvironment(): DataEnvironment {
+  return {
+    learnerProgress: staticLearnerProgressAdapter,
+    waitlist: staticWaitlistAdapter,
+  };
+}

--- a/src/lib/data/data-environment.tsx
+++ b/src/lib/data/data-environment.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { createContext, useContext, useMemo } from "react";
+
+import { createLocalDataEnvironment } from "./adapters/local-storage";
+import { createStaticDataEnvironment } from "./adapters/static";
+import type { DataEnvironment, LearnerProgressAdapter, WaitlistAdapter } from "./types";
+
+const DataEnvironmentContext = createContext<DataEnvironment | null>(null);
+
+export function DataEnvironmentProvider({ children }: { children: React.ReactNode }) {
+  const value = useMemo<DataEnvironment>(() => {
+    if (typeof window === "undefined") {
+      return createStaticDataEnvironment();
+    }
+    return createLocalDataEnvironment();
+  }, []);
+
+  return <DataEnvironmentContext.Provider value={value}>{children}</DataEnvironmentContext.Provider>;
+}
+
+function useDataEnvironment() {
+  const context = useContext(DataEnvironmentContext);
+  if (!context) {
+    throw new Error("DataEnvironmentProvider is missing. Wrap your app with the provider before using data hooks.");
+  }
+  return context;
+}
+
+export function useLearnerProgressAdapter(): LearnerProgressAdapter {
+  return useDataEnvironment().learnerProgress;
+}
+
+export function useWaitlistAdapter(): WaitlistAdapter {
+  return useDataEnvironment().waitlist;
+}

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -1,0 +1,32 @@
+export type LearnerFocusArea = "agents" | "prototyping" | "operations" | "governance" | "story";
+
+export interface LearnerProgressSnapshot {
+  focusArea: LearnerFocusArea;
+  checkpoints: Record<string, boolean>;
+  lastUpdated: string;
+}
+
+export interface LearnerProgressAdapter {
+  load(): Promise<LearnerProgressSnapshot>;
+  save(snapshot: LearnerProgressSnapshot): Promise<void>;
+  subscribe?(callback: (snapshot: LearnerProgressSnapshot) => void): () => void;
+}
+
+export interface WaitlistSubmission {
+  fullName: string;
+  email: string;
+  role: string;
+  focusArea: LearnerFocusArea;
+  desiredTier: "workspace" | "advisory" | "creator" | "enterprise";
+  notes?: string;
+  submittedAt: string;
+}
+
+export interface WaitlistAdapter {
+  submit(entry: WaitlistSubmission): Promise<void>;
+}
+
+export interface DataEnvironment {
+  learnerProgress: LearnerProgressAdapter;
+  waitlist: WaitlistAdapter;
+}

--- a/src/lib/learner-progress.ts
+++ b/src/lib/learner-progress.ts
@@ -2,58 +2,71 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-const STORAGE_KEY = "ai-architect-progress";
+import { useLearnerProgressAdapter } from "./data/data-environment";
+import type { LearnerFocusArea, LearnerProgressSnapshot } from "./data/types";
 
-export type LearnerFocusArea = "agents" | "prototyping" | "operations" | "governance" | "story";
+export type { LearnerFocusArea } from "./data/types";
 
-export type LearnerProgressState = {
-  focusArea: LearnerFocusArea;
-  checkpoints: Record<string, boolean>;
-  lastUpdated: string;
-};
+export type LearnerProgressState = LearnerProgressSnapshot;
 
-const defaultState: LearnerProgressState = {
+const defaultState: LearnerProgressSnapshot = {
   focusArea: "agents",
   checkpoints: {},
   lastUpdated: new Date().toISOString(),
 };
 
-function readState(): LearnerProgressState {
-  if (typeof window === "undefined") return defaultState;
-  try {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    if (!stored) return defaultState;
-    const parsed = JSON.parse(stored) as LearnerProgressState;
-    return {
-      focusArea: parsed.focusArea ?? defaultState.focusArea,
-      checkpoints: parsed.checkpoints ?? {},
-      lastUpdated: parsed.lastUpdated ?? defaultState.lastUpdated,
-    };
-  } catch (error) {
-    console.warn("Unable to parse learner progress state", error);
-    return defaultState;
-  }
-}
-
-function writeState(next: LearnerProgressState) {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-}
-
 export function useLearnerProgress() {
-  const [state, setState] = useState<LearnerProgressState>(() => readState());
+  const adapter = useLearnerProgressAdapter();
+  const [state, setState] = useState<LearnerProgressSnapshot>(defaultState);
+  const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
-    setState(readState());
-  }, []);
+    let active = true;
 
-  const updateState = useCallback((updater: (prev: LearnerProgressState) => LearnerProgressState) => {
-    setState((prev) => {
-      const next = updater(prev);
-      writeState(next);
-      return next;
+    adapter
+      .load()
+      .then((snapshot) => {
+        if (!active) return;
+        setState(snapshot);
+      })
+      .catch((error) => {
+        console.warn("Failed to load learner progress", error);
+      })
+      .finally(() => {
+        if (active) {
+          setIsHydrated(true);
+        }
+      });
+
+    const unsubscribe = adapter.subscribe?.((snapshot) => {
+      setState(snapshot);
     });
-  }, []);
+
+    return () => {
+      active = false;
+      unsubscribe?.();
+    };
+  }, [adapter]);
+
+  const persist = useCallback(
+    (snapshot: LearnerProgressSnapshot) => {
+      void adapter.save(snapshot).catch((error) => {
+        console.error("Failed to persist learner progress", error);
+      });
+    },
+    [adapter],
+  );
+
+  const updateState = useCallback(
+    (updater: (prev: LearnerProgressSnapshot) => LearnerProgressSnapshot) => {
+      setState((prev) => {
+        const next = updater(prev);
+        persist(next);
+        return next;
+      });
+    },
+    [persist],
+  );
 
   const toggleCheckpoint = useCallback(
     (id: string) => {
@@ -92,9 +105,12 @@ export function useLearnerProgress() {
     setFocusArea,
     toggleCheckpoint,
     completionRatio,
+    isHydrated,
   };
 }
 
 export function formatCompletion(ratio: number) {
-  return Math.round(ratio * 100).toString().concat("%");
+  return Math.round(ratio * 100)
+    .toString()
+    .concat("%");
 }


### PR DESCRIPTION
## Summary
- add a client data environment with local adapters that mirror the planned Supabase contracts for learner progress and waitlist submissions
- wrap the app with the new provider and refactor the learner progress hook to use asynchronous adapter calls
- replace mailto calls-to-action with a dedicated waitlist section and form that persists interest locally until Supabase is wired up

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4f12c40e88320913dacde758dfae4